### PR TITLE
Ensure that qubes.user-dirs state actually works

### DIFF
--- a/qubes/user-dirs.sls
+++ b/qubes/user-dirs.sls
@@ -48,6 +48,11 @@ directory_srv_user_pillar:
       - group
       - mode
 
+enable_user_salt:
+  file.symlink:
+    - name: /srv/salt/_tops/base/user-dirs.top
+    - target: ../../qubes/user-dirs.top
+
 # User 'formulas' directory and file permissions
 # Note: using custom ID due to possible conflicts
 directory_srv_user_formulas:


### PR DESCRIPTION
It worked for systems upgraded from earlier versions of Qubes OS, but not for fresh installs of R4.2-rc3 and up.

I don’t have a broken system to test this on so I can’t see if it works for me, but presumably @rapenne-s can.

Fixes: QubesOS/qubes-issues#8491